### PR TITLE
security: harden XML/RNG/IPN parsing; require PHP 8.3+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .DS_Store
 /.idea
-
+/vendor

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 /.idea
 /vendor
+/.phpunit.cache
+/.phpunit.result.cache
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "birkof/netopia-mobilpay",
     "description": "Mirroring MobilePay library with composer PSR-4 autoloading capability.",
     "type": "library",
+    "license": "MIT",
     "authors": [
         {
             "name": "Daniel STANCU",
@@ -9,6 +10,7 @@
         }
     ],
     "require": {
+        "php": ">=8.3",
         "ext-dom": "*",
         "ext-openssl": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,22 @@
     "autoload": {
         "psr-4" : {
             "Mobilpay\\Payment\\" : "src/Mobilpay/Payment/"
+        },
+        "classmap": [
+            "src/Mobilpay/Global.php"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^11",
+        "phpstan/phpstan": "^2"
+    },
+    "scripts": {
+        "test": "phpunit",
+        "stan": "phpstan analyse"
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,1345 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to function is_array\(\) with array\<mixed\> will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 2
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Call to function is_null\(\) with int\<0, 255\> will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 2
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Constant DEFAULT_CODE_LENGTH not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:attachQueryString\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:attachQueryString\(\) has parameter \$query_string with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:attachQueryString\(\) has parameter \$url with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:buildCRC\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:buildCRC\(\) has parameter \$params with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:buildQueryString\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:buildQueryString\(\) has parameter \$params with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:formatMessage\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:formatMessage\(\) has parameter \$message_format with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:formatMessage\(\) has parameter \$message_parameters with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:generatePassword\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:generatePassword\(\) has parameter \$alpha_interval with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:generatePassword\(\) has parameter \$length with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:generatePassword\(\) has parameter \$num_interval with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:isValidMsisdn\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:isValidMsisdn\(\) has parameter \$param_msisdn with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:unreferrencedVariable\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Method Mobilpay\\MobilpayGlobal\:\:unreferrencedVariable\(\) has parameter \$variable with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Parameter \#1 \$character of function ord expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 4
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Parameter \#1 \$min \(0\) of function random_int expects lower number than parameter \#2 \$max \(int\<\-1, 254\>\)\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Parameter \#2 \$replace of function str_replace expects array\<string\>\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Mobilpay/Global.php
+
+		-
+			message: '#^Call to an undefined method DOMNode\:\:getElementsByTagName\(\)\.$#'
+			identifier: method.notFound
+			count: 5
+			path: src/Mobilpay/Payment/Address.php
+
+		-
+			message: '#^Cannot call method getNamedItem\(\) on DOMNamedNodeMap\<DOMAttr\>\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/Mobilpay/Payment/Address.php
+
+		-
+			message: '#^Instanceof between DOMDocument and DOMDocument will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: src/Mobilpay/Payment/Address.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Address\:\:createXmlElement\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Address.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Address\:\:createXmlElement\(\) has parameter \$nodeName with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Payment/Address.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Address\:\:loadFromXml\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Address.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Address\:\:toArray\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Address.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Address\:\:\$address has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Address.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Address\:\:\$email has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Address.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Address\:\:\$firstName has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Address.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Address\:\:\$lastName has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Address.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Address\:\:\$mobilePhone has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Address.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Address\:\:\$type has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Address.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Exchange\\Rate\:\:createXmlElement\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Exchange/Rate.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Exchange\\Rate\:\:loadFromXml\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Exchange/Rate.php
+
+		-
+			message: '#^Access to undefined constant Mobilpay\\Payment\\Instrument\\Card\:\:ERROR_INVALID_PARAMETER\.$#'
+			identifier: classConstant.notFound
+			count: 1
+			path: src/Mobilpay/Payment/Instrument/Card.php
+
+		-
+			message: '#^Call to an undefined method DOMNode\:\:getElementsByTagName\(\)\.$#'
+			identifier: method.notFound
+			count: 5
+			path: src/Mobilpay/Payment/Instrument/Card.php
+
+		-
+			message: '#^Instanceof between DOMDocument and DOMDocument will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: src/Mobilpay/Payment/Instrument/Card.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Instrument\\Card\:\:createXmlElement\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Instrument/Card.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Instrument\\Card\:\:loadFromXml\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Instrument/Card.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Instrument\\Card\:\:\$cvv2 has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Instrument/Card.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Instrument\\Card\:\:\$expMonth has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Instrument/Card.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Instrument\\Card\:\:\$expYear has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Instrument/Card.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Instrument\\Card\:\:\$name has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Instrument/Card.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Instrument\\Card\:\:\$number has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Instrument/Card.php
+
+		-
+			message: '#^Call to an undefined method DOMNode\:\:getElementsByTagName\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Call to an undefined method Mobilpay\\Payment\\Invoice\\Item\:\:getTotalAmount\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Cannot call method getNamedItem\(\) on DOMNamedNodeMap\<DOMAttr\>\|null\.$#'
+			identifier: method.nonObject
+			count: 6
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Caught class Mobilpay\\Payment\\Exception not found\.$#'
+			identifier: class.notFound
+			count: 6
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Class Mobilpay\\Payment\\Exchange\\Rate constructor invoked with 1 parameter, 0 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Instanceof between DOMDocument and DOMDocument will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Loose comparison using \=\= between null and null will always evaluate to true\.$#'
+			identifier: equal.alwaysTrue
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Invoice\:\:addHeadExchangeRate\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Invoice\:\:addHeadItem\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Invoice\:\:addTailExchangeRate\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Invoice\:\:addTailItem\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Invoice\:\:createXmlElement\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Invoice\:\:getBillingAddress\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Invoice\:\:getShippingAddress\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Invoice\:\:loadFromXml\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Invoice\:\:removeHeadExchangeRate\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Invoice\:\:removeHeadItem\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Invoice\:\:removeTailExchangeRate\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Invoice\:\:removeTailItem\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Invoice\:\:setBillingAddress\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Invoice\:\:setShippingAddress\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Parameter \#1 \$node of method DOMNode\:\:appendChild\(\) expects DOMElement, DOMElement\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Invoice\:\:\$amount has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Invoice\:\:\$billingAddress has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Invoice\:\:\$currency has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Invoice\:\:\$details has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Invoice\:\:\$exchangeRates has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Invoice\:\:\$installments has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Invoice\:\:\$items has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Invoice\:\:\$promotionCode has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Invoice\:\:\$selectedInstallments has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Invoice\:\:\$shippingAddress has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Invoice\:\:\$tokenId has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Variable \$xmlItems might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: src/Mobilpay/Payment/Invoice.php
+
+		-
+			message: '#^Call to an undefined method DOMNode\:\:getElementsByTagName\(\)\.$#'
+			identifier: method.notFound
+			count: 6
+			path: src/Mobilpay/Payment/Invoice/Item.php
+
+		-
+			message: '#^Instanceof between DOMDocument and DOMDocument will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: src/Mobilpay/Payment/Invoice/Item.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Invoice\\Item\:\:createXmlElement\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Invoice/Item.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Invoice\\Item\:\:getTotalAmmount\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Invoice/Item.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Invoice\\Item\:\:loadFromXml\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Invoice/Item.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Invoice\\Item\:\:\$code has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Invoice/Item.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Invoice\\Item\:\:\$measurment has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Invoice/Item.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Invoice\\Item\:\:\$name has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Invoice/Item.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Invoice\\Item\:\:\$price has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Invoice/Item.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Invoice\\Item\:\:\$quantity has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Invoice/Item.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Invoice\\Item\:\:\$vat has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Invoice/Item.php
+
+		-
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^Call to function is_null\(\) with string will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 3
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\:\:buildParametersList\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^PHPDoc tag @var has invalid value \(string\(10\)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 295 on line 6$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^PHPDoc tag @var has invalid value \(string\(24\)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 133 on line 4$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^PHPDoc tag @var has invalid value \(string\(255\)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 94 on line 4$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^PHPDoc tag @var has invalid value \(string\(255\)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 96 on line 4$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^PHPDoc tag @var has invalid value \(string\(64\)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 208 on line 5$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^Parameter \#1 \$string of function urlencode expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^Parameter &\$enc_data by\-ref type of method Mobilpay\\Payment\\Request\:\:buildAccessParameters\(\) expects string, null given\.$#'
+			identifier: parameterByRef.type
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^Parameter &\$env_key by\-ref type of method Mobilpay\\Payment\\Request\:\:buildAccessParameters\(\) expects string, null given\.$#'
+			identifier: parameterByRef.type
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\:\:\$m_currency has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\:\:\$m_details has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\:\:\$m_first_name has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\:\:\$m_last_name has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\:\:\$m_msisdn has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\:\:\$m_params type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\:\:\$m_price has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\:\:\$m_service has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\:\:\$m_signature has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\:\:\$m_tran_id has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\:\:\$m_type has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request.php
+
+		-
+			message: '#^Call to function is_null\(\) with string will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 3
+			path: src/Mobilpay/Payment/Request/Card.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\Card\:\:_loadFromXml\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/Card.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\Card\:\:_prepare\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/Card.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: src/Mobilpay/Payment/Request/Card.php
+
+		-
+			message: '#^Parameter \#1 \$data of method DOMDocument\:\:createCDATASection\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Mobilpay/Payment/Request/Card.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Card\:\:\$invoice has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Card.php
+
+		-
+			message: '#^Result of \|\| is always true\.$#'
+			identifier: booleanOr.alwaysTrue
+			count: 1
+			path: src/Mobilpay/Payment/Request/Card.php
+
+		-
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Call to function is_null\(\) with int will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 2
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Cannot access property \$amount on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Cannot access property \$attributes on DOMElement\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Cannot access property \$currency on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Cannot access property \$id on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Cannot access property \$nodeValue on DOMElement\|null\.$#'
+			identifier: property.nonObject
+			count: 19
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Cannot access property \$third_party on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Cannot call method getElementsByTagName\(\) on DOMElement\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Loose comparison using \=\= between false and false will always evaluate to true\.$#'
+			identifier: equal.alwaysTrue
+			count: 2
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\Notify\:\:_loadFromQueryString\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\Notify\:\:loadFromXml\(\) should return \$this\(Mobilpay\\Payment\\Request\\Notify\) but return statement is missing\.$#'
+			identifier: return.missing
+			count: 2
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$elem with type DOMNode is not subtype of native type DOMElement\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^PHPDoc tag @throws with type Mobilpay\\Payment\\Request\\Exception is not subtype of Throwable$#'
+			identifier: throws.notThrowable
+			count: 2
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property DOMNode\:\:\$nodeValue \(string\|null\) does not accept int\.$#'
+			identifier: assign.propertyType
+			count: 2
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$_crc \(string\) does not accept string\|null\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$action has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$current_payment_count \(int\) does not accept string\|null\.$#'
+			identifier: assign.propertyType
+			count: 2
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$customer has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$customer_id has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$customer_type has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$discounts type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$errorCode has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$errorMessage has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$installments has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$issuer has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$originalAmount has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$paidByPhone has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$pan_masked has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$params type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$paymentCode has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$paymentInstrumentId \(int\) does not accept string\|null\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$processedAmount has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$promotionAmount has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$purchaseId \(string\) does not accept string\|null\.$#'
+			identifier: assign.propertyType
+			count: 2
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$rrn has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$timestamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$token_expiration_date has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$token_id has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Notify\:\:\$validationCode has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Notify.php
+
+		-
+			message: '#^Call to an undefined method DOMNode\:\:getElementsByTagName\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Cannot access property \$attributes on DOMElement\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Cannot access property \$nodeValue on DOMAttr\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Cannot call method getNamedItem\(\) on DOMNamedNodeMap\<DOMAttr\>\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:__get\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:__get\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:__isset\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:__set\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:__set\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:_factoryFromQueryString\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:_factoryFromQueryString\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:_factoryFromXml\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:_loadFromXml\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:_parseFromXml\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:_prepare\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:_setRequestInfo\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:_setRequestInfo\(\) has parameter \$reqData with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:_setRequestInfo\(\) has parameter \$reqVersion with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:encrypt\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:encrypt\(\) has parameter \$x509FilePath with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:factory\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:factory\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:factoryFromEncrypted\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:factoryFromEncrypted\(\) has parameter \$encData with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:factoryFromEncrypted\(\) has parameter \$envKey with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:factoryFromEncrypted\(\) has parameter \$privateKeyFilePath with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:factoryFromEncrypted\(\) has parameter \$privateKeyPassword with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:getEncData\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:getEnvKey\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:getRequestIdentifier\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\RequestAbstract\:\:getRequestInfo\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^PHPDoc tag @var has invalid value \(string\(64\)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 131 on line 4$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^PHPDoc tag @var has invalid value \(string\(64\)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 234 on line 5$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Parameter \#1 \$elem of method Mobilpay\\Payment\\Request\\Sms\:\:_loadFromXml\(\) expects DOMElement, DOMElement\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strlen expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\RequestAbstract\:\:\$_objRequestInfo has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\RequestAbstract\:\:\$_objRequestParams has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\RequestAbstract\:\:\$_requestIdentifier has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\RequestAbstract\:\:\$_xmlDoc has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\RequestAbstract\:\:\$objPmNotify has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\RequestAbstract\:\:\$objReqNotify has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\RequestAbstract\:\:\$orderId has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\RequestAbstract\:\:\$outEncData has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\RequestAbstract\:\:\$outEnvKey has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\RequestAbstract\:\:\$params has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\RequestAbstract\:\:\$service has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\RequestAbstract\:\:\$signature has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\RequestAbstract\:\:\$timestamp has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\RequestAbstract\:\:\$type has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and false will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 2
+			path: src/Mobilpay/Payment/Request/RequestAbstract.php
+
+		-
+			message: '#^Call to function is_null\(\) with string will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 3
+			path: src/Mobilpay/Payment/Request/Sms.php
+
+		-
+			message: '#^Cannot access property \$nodeValue on DOMElement\|null\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: src/Mobilpay/Payment/Request/Sms.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\Sms\:\:_loadFromQueryString\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/Sms.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\Sms\:\:_loadFromQueryString\(\) has parameter \$queryString with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Mobilpay/Payment/Request/Sms.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\Sms\:\:_loadFromXml\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/Sms.php
+
+		-
+			message: '#^Method Mobilpay\\Payment\\Request\\Sms\:\:_prepare\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Mobilpay/Payment/Request/Sms.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: src/Mobilpay/Payment/Request/Sms.php
+
+		-
+			message: '#^PHPDoc tag @var has invalid value \(string\(10\)\)\: Unexpected token "\(", expected TOKEN_HORIZONTAL_WS at offset 263 on line 5$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/Mobilpay/Payment/Request/Sms.php
+
+		-
+			message: '#^Parameter \#1 \$string of function urlencode expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Mobilpay/Payment/Request/Sms.php
+
+		-
+			message: '#^Property Mobilpay\\Payment\\Request\\Sms\:\:\$msisdn has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/Mobilpay/Payment/Request/Sms.php
+
+		-
+			message: '#^Result of \|\| is always true\.$#'
+			identifier: booleanOr.alwaysTrue
+			count: 1
+			path: src/Mobilpay/Payment/Request/Sms.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 9
+    paths:
+        - src

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         failOnWarning="true"
+         failOnRisky="true">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Mobilpay/Global.php
+++ b/src/Mobilpay/Global.php
@@ -124,10 +124,11 @@ class MobilpayGlobal
             return null;
         }
 
-        srand(intval((double)microtime() * 1000000));
         $password = "";
         while ($length) {
-            $value = rand() % $max_value;
+            // Cryptographically secure source; same 0..(max_value-1) range as the
+            // former rand() % $max_value, but unpredictable and without modulo bias.
+            $value = random_int(0, $max_value - 1);
             if (!is_null($alpha_start) && !is_null($alpha_end) && is_array($alpha_exclude)) {
                 if ($value >= $alpha_start && $value <= $alpha_end && !in_array($value, $alpha_exclude)) {
                     $password .= chr($value);
@@ -154,6 +155,7 @@ class MobilpayGlobal
      * digit (except 0)
      *
      * @return string
+     * @throws \Exception If the platform cannot gather sufficient entropy.
      */
     public static function generateSellerSignature()
     {
@@ -163,13 +165,14 @@ class MobilpayGlobal
         $al_end = ord("Z");
         $al_exclude = [ord("O"), ord("I")];
         $num_exclude = [ord("0")];
-        srand(intval((double)microtime() * 1000000));
         $signature_parts = [];
         for ($index = 0; $index < 5; $index++) {
             $signature_part = "";
             $length = 4;
             while ($length) {
-                $value = rand() % $al_end;
+                // Cryptographically secure source; preserves the former 0..($al_end-1)
+                // range of rand() % $al_end, but unpredictable and without modulo bias.
+                $value = random_int(0, $al_end - 1);
                 if ($value >= $al_start && $value <= $al_end && !in_array($value, $al_exclude)) {
                     $signature_part .= chr($value);
                     $length--;

--- a/src/Mobilpay/Payment/Request/Notify.php
+++ b/src/Mobilpay/Payment/Request/Notify.php
@@ -202,10 +202,12 @@ class Notify
             $this->discounts = [];
             foreach ($doaElems as $de) {
                 $doaEntry = new \stdClass();
-                $doaEntry->id = $de->attributes->getNamedItem('id')->nodeValue;
-                $doaEntry->amount = $de->attributes->getNamedItem('amount')->nodeValue;
-                $doaEntry->currency = $de->attributes->getNamedItem('currency')->nodeValue;
-                $doaEntry->third_party = $de->attributes->getNamedItem('third_party')->nodeValue;
+                // Null-safe: a malformed <discount> missing any attribute must not
+                // raise a fatal "read property nodeValue on null" and abort IPN parsing.
+                $doaEntry->id = $de->attributes->getNamedItem('id')?->nodeValue;
+                $doaEntry->amount = $de->attributes->getNamedItem('amount')?->nodeValue;
+                $doaEntry->currency = $de->attributes->getNamedItem('currency')?->nodeValue;
+                $doaEntry->third_party = $de->attributes->getNamedItem('third_party')?->nodeValue;
                 $this->discounts[] = $doaEntry;
             }
         }

--- a/src/Mobilpay/Payment/Request/RequestAbstract.php
+++ b/src/Mobilpay/Payment/Request/RequestAbstract.php
@@ -117,10 +117,14 @@ abstract class RequestAbstract
 
     public $objReqNotify = null;
 
+    /**
+     * @throws \Exception If the platform cannot gather sufficient entropy.
+     */
     public function __construct()
     {
-        srand(intval((double)microtime() * 1000000));
-        $this->_requestIdentifier = md5(uniqid(rand()));
+        // Cryptographically secure, unpredictable request identifier. 32 hex chars,
+        // same length/charset as the previous md5() output for backward compatibility.
+        $this->_requestIdentifier = bin2hex(random_bytes(16));
 
         $this->_objRequestParams = new \stdClass();
     }
@@ -133,7 +137,11 @@ abstract class RequestAbstract
     {
         $objPmReq = null;
         $xmlDoc = new DOMDocument();
-        if (@$xmlDoc->loadXML($data) === true) {
+        // LIBXML_NONET blocks network access during parsing (defense-in-depth against
+        // SSRF/XXE via external resources). External entity substitution is already
+        // disabled by default since libxml 2.9; passing the flag makes the intent
+        // explicit and keeps parsing safe on older libxml builds too.
+        if (@$xmlDoc->loadXML($data, LIBXML_NONET) === true) {
             //try to create payment request from xml
             $objPmReq = self::_factoryFromXml($xmlDoc);
             $objPmReq->_setRequestInfo(self::VERSION_XML, $data);

--- a/tests/MobilpayGlobalTest.php
+++ b/tests/MobilpayGlobalTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Mobilpay\MobilpayGlobal;
+use PHPUnit\Framework\TestCase;
+
+final class MobilpayGlobalTest extends TestCase
+{
+    public function testBuildCrcExcludesCrcKeyAndReturnsMd5(): void
+    {
+        $params = ['signature' => 'ABC', 'amount' => '100', 'crc' => 'stale'];
+
+        $crc = MobilpayGlobal::buildCRC($params);
+
+        $this->assertSame(md5('signature=ABC&amount=100'), $crc);
+        $this->assertSame(32, strlen($crc));
+    }
+
+    public function testBuildCrcExclusionIsCaseInsensitive(): void
+    {
+        $this->assertSame(md5('a=1'), MobilpayGlobal::buildCRC(['a' => '1', 'CRC' => 'x']));
+    }
+
+    public function testBuildQueryStringJoinsPairsWithAmpersand(): void
+    {
+        $this->assertSame('a=1&b=2', MobilpayGlobal::buildQueryString(['a' => '1', 'b' => '2']));
+    }
+
+    public function testAttachQueryStringReturnsUrlUnchangedForEmptyQuery(): void
+    {
+        $this->assertSame('https://x.test/cb', MobilpayGlobal::attachQueryString('https://x.test/cb', ''));
+    }
+
+    public function testAttachQueryStringAddsQuestionMarkThenAmpersand(): void
+    {
+        $this->assertSame('https://x.test/cb?a=1', MobilpayGlobal::attachQueryString('https://x.test/cb', 'a=1'));
+        $this->assertSame('https://x.test/cb?z=0&a=1', MobilpayGlobal::attachQueryString('https://x.test/cb?z=0', 'a=1'));
+    }
+
+    public function testIsValidMsisdnAcceptsRomanianMobile(): void
+    {
+        $this->assertTrue(MobilpayGlobal::isValidMsisdn('0712345678'));
+        $this->assertTrue(MobilpayGlobal::isValidMsisdn('40712345678'));
+    }
+
+    public function testIsValidMsisdnRejectsInvalidNumbers(): void
+    {
+        $this->assertFalse(MobilpayGlobal::isValidMsisdn('0612345678'));
+        $this->assertFalse(MobilpayGlobal::isValidMsisdn('07123'));
+        $this->assertFalse(MobilpayGlobal::isValidMsisdn('not-a-number'));
+    }
+
+    public function testGenerateSellerSignatureMatchesFormatAndExcludedCharset(): void
+    {
+        $signature = MobilpayGlobal::generateSellerSignature();
+
+        // five groups of four chars; uppercase letters minus O/I, digits minus 0.
+        $this->assertMatchesRegularExpression('/^[A-HJ-NP-Z1-9]{4}(-[A-HJ-NP-Z1-9]{4}){4}$/', $signature);
+        $this->assertSame(24, strlen($signature));
+    }
+
+    public function testGeneratePasswordReturnsRequestedLengthWithinCharset(): void
+    {
+        $password = MobilpayGlobal::generatePassword(
+            ['first' => '0', 'last' => '9', 'exclude' => []],
+            ['first' => 'A', 'last' => 'Z', 'exclude' => []],
+            12,
+        );
+
+        $this->assertSame(12, strlen($password));
+        $this->assertMatchesRegularExpression('/^[0-9A-Z]{12}$/', $password);
+    }
+}

--- a/tests/Payment/Request/NotifyTest.php
+++ b/tests/Payment/Request/NotifyTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Payment\Request;
+
+use DOMDocument;
+use Mobilpay\Payment\Request\Notify;
+use PHPUnit\Framework\TestCase;
+
+final class NotifyTest extends TestCase
+{
+    public function testCreateXmlElementAndLoadFromXmlRoundTrip(): void
+    {
+        $notify = new Notify();
+        $notify->action = 'confirmed';
+        $notify->purchaseId = 'PID-123';
+        $notify->originalAmount = '100.00';
+        $notify->processedAmount = '100.00';
+        $notify->errorCode = '0';
+        $notify->errorMessage = 'Approved';
+
+        $doc = new DOMDocument('1.0', 'utf-8');
+        $doc->appendChild($notify->createXmlElement($doc));
+
+        $parsed = new Notify();
+        $parsed->loadFromXml($doc->documentElement);
+
+        $this->assertSame('confirmed', $parsed->action);
+        $this->assertSame('PID-123', $parsed->purchaseId);
+        $this->assertSame('100.00', $parsed->originalAmount);
+        $this->assertSame('100.00', $parsed->processedAmount);
+        $this->assertSame('0', $parsed->errorCode);
+        $this->assertSame('Approved', $parsed->errorMessage);
+        $this->assertNotEmpty($parsed->getCrc());
+    }
+
+    public function testLoadFromXmlParsesWellFormedDiscounts(): void
+    {
+        $notify = $this->loadNotify(
+            '<mobilpay timestamp="20240101000000" crc="abc">'
+            . '<action>confirmed</action>'
+            . '<discounts><discount id="1" amount="10" currency="RON" third_party="0"/></discounts>'
+            . '</mobilpay>'
+        );
+
+        $this->assertCount(1, $notify->discounts);
+        $this->assertSame('1', $notify->discounts[0]->id);
+        $this->assertSame('10', $notify->discounts[0]->amount);
+        $this->assertSame('RON', $notify->discounts[0]->currency);
+        $this->assertSame('0', $notify->discounts[0]->third_party);
+    }
+
+    /**
+     * Regression for the null-safe discount parsing fix: a malformed <discount>
+     * missing attributes must yield null fields, not a fatal "nodeValue on null".
+     */
+    public function testLoadFromXmlDoesNotCrashOnDiscountMissingAttributes(): void
+    {
+        $notify = $this->loadNotify(
+            '<mobilpay timestamp="20240101000000" crc="abc">'
+            . '<action>confirmed</action>'
+            . '<discounts><discount id="1"/></discounts>'
+            . '</mobilpay>'
+        );
+
+        $this->assertCount(1, $notify->discounts);
+        $this->assertSame('1', $notify->discounts[0]->id);
+        $this->assertNull($notify->discounts[0]->amount);
+        $this->assertNull($notify->discounts[0]->currency);
+        $this->assertNull($notify->discounts[0]->third_party);
+    }
+
+    public function testLoadFromXmlThrowsWhenCrcAttributeMissing(): void
+    {
+        $this->expectException(\Exception::class);
+
+        $this->loadNotify('<mobilpay timestamp="20240101000000"><action>confirmed</action></mobilpay>');
+    }
+
+    public function testLoadFromXmlThrowsWhenActionElementMissing(): void
+    {
+        $this->expectException(\Exception::class);
+
+        $this->loadNotify('<mobilpay timestamp="20240101000000" crc="abc"></mobilpay>');
+    }
+
+    private function loadNotify(string $xml): Notify
+    {
+        $doc = new DOMDocument();
+        $doc->loadXML($xml);
+
+        $notify = new Notify();
+        $notify->loadFromXml($doc->documentElement);
+
+        return $notify;
+    }
+}

--- a/tests/Payment/Request/RequestAbstractTest.php
+++ b/tests/Payment/Request/RequestAbstractTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Payment\Request;
+
+use Mobilpay\Payment\Request\RequestAbstract;
+use Mobilpay\Payment\Request\Sms;
+use PHPUnit\Framework\TestCase;
+
+final class RequestAbstractTest extends TestCase
+{
+    public function testRequestIdentifierIs32HexChars(): void
+    {
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{32}$/', (new Sms())->getRequestIdentifier());
+    }
+
+    public function testRequestIdentifiersAreUnique(): void
+    {
+        $this->assertNotSame(
+            (new Sms())->getRequestIdentifier(),
+            (new Sms())->getRequestIdentifier(),
+        );
+    }
+
+    public function testFactoryParsesXmlOrderIntoSms(): void
+    {
+        $xml = '<order type="sms" id="ORD-1"><signature>SIG-1</signature><service>SVC-1</service></order>';
+
+        $req = RequestAbstract::factory($xml);
+
+        $this->assertInstanceOf(Sms::class, $req);
+        $this->assertSame('ORD-1', $req->orderId);
+        $this->assertSame('SIG-1', $req->signature);
+        $this->assertSame('SVC-1', $req->service);
+        $this->assertSame(RequestAbstract::VERSION_XML, $req->getRequestInfo()->reqVersion);
+    }
+
+    public function testFactoryFallsBackToQueryStringParsing(): void
+    {
+        $req = RequestAbstract::factory('signature=SIG-2&service=SVC-2&tran_id=ORD-2');
+
+        $this->assertInstanceOf(Sms::class, $req);
+        $this->assertSame('ORD-2', $req->orderId);
+        $this->assertSame('SIG-2', $req->signature);
+        $this->assertSame(RequestAbstract::VERSION_QUERY_STRING, $req->getRequestInfo()->reqVersion);
+    }
+
+    public function testEncryptThenFactoryFromEncryptedRoundTrip(): void
+    {
+        if (!$this->rc4Available()) {
+            $this->markTestSkipped('RC4 cipher unavailable in this OpenSSL build (expected on OpenSSL 3+).');
+        }
+
+        $pkey = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+        $this->assertNotFalse($pkey);
+        openssl_pkey_export($pkey, $privatePem);
+        $publicPem = (string) openssl_pkey_get_details($pkey)['key'];
+
+        $keyFile = (string) tempnam(sys_get_temp_dir(), 'mpkey');
+        file_put_contents($keyFile, $privatePem);
+
+        try {
+            $sms = new Sms();
+            $sms->signature = 'SIG-RT';
+            $sms->service = 'SVC-RT';
+            $sms->orderId = 'ORD-RT';
+            $sms->encrypt($publicPem);
+
+            $decoded = RequestAbstract::factoryFromEncrypted($sms->getEnvKey(), $sms->getEncData(), $keyFile);
+
+            $this->assertInstanceOf(Sms::class, $decoded);
+            $this->assertSame('ORD-RT', $decoded->orderId);
+            $this->assertSame('SIG-RT', $decoded->signature);
+            $this->assertSame('SVC-RT', $decoded->service);
+        } finally {
+            @unlink($keyFile);
+        }
+    }
+
+    private function rc4Available(): bool
+    {
+        $pkey = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+        if ($pkey === false) {
+            return false;
+        }
+
+        $sealed = null;
+        $envKeys = null;
+        $publicPem = (string) openssl_pkey_get_details($pkey)['key'];
+
+        return @openssl_seal('probe', $sealed, $envKeys, [$publicPem], 'RC4') !== false;
+    }
+}


### PR DESCRIPTION
## Summary

Defense-in-depth hardening of the user-reachable parsing/crypto paths, plus a platform floor of PHP 8.3+ and an explicit MIT license.

Behavior-preserving except for one fixed crash (malformed `<discount>` IPN). No public signatures changed.

> **Supersedes #6 (srand deprecation fix).** #6 patched the PHP 8.4 `srand(float)` deprecation with `srand(intval(...))` but kept the weak seeded `rand()` + modulo bias (CWE-338). This PR replaces that whole path with `random_int()` / `random_bytes()` — deprecation gone **and** predictability gone. Rebased on current `master`; the RNG lines from #6 are intentionally dropped in favour of the CSPRNG version.
>
> Independent of #8 (explicit nullable types) — no file overlap.

## Changes

| File | Change | Why |
|------|--------|-----|
| `RequestAbstract.php` | `loadXML($data, LIBXML_NONET)` | Block network resource fetch during XML parse — explicit defense vs SSRF/XXE (entities already off by default since libxml 2.9; flag makes intent explicit + safe on old builds) |
| `RequestAbstract.php` | request identifier → `bin2hex(random_bytes(16))` | Was `md5(uniqid(rand()))` — predictable. CSPRNG now; 32-hex format preserved |
| `Global.php` | `random_int()` ×2, dropped `srand()` ×2 | `generatePassword`/`generateSellerSignature` used seeded `rand()` with modulo bias — predictable signatures/passwords |
| `Notify.php` | null-safe `?->nodeValue` on `<discount>` attrs | Malformed discount element raised a fatal `Error: nodeValue on null`, aborting IPN parsing |
| `composer.json` | `"php": ">=8.3"`, `"license": "MIT"` | Pin runtime; declare license |
| `.gitignore` | ignore `/vendor` | Repo hygiene |

## Behavior notes

- Identifier stays 32 hex chars — drop-in, no downstream length break.
- Password/signature ranges preserved exactly (`0..max-1`), including the pre-existing top-bound exclusion — range bug intentionally left as-is (out of scope).
- `random_int`/`random_bytes` throw `\Exception` on entropy failure (rare, fail-closed); `@throws` annotated on `__construct` and `generateSellerSignature`.

## Test plan

- [x] `php -l` clean on all changed files (PHP 8.4)
- [x] `composer validate` — valid, no warnings
- [x] Rebased on `master` post #6/#8 merge — conflicts resolved, no markers, no live `srand`/`rand()` remaining
- [ ] TODO: no PHPUnit/PHPStan in repo yet — add suite + level 9 config and cover CRC / XML round-trip / discount-parse / encrypt paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)