### PR TITLE
fix: support OpenSSL 3 by replacing RC4 seal cipher with aes-256-cbc + IV

### DIFF
--- a/src/Mobilpay/Global.php
+++ b/src/Mobilpay/Global.php
@@ -15,6 +15,34 @@ class MobilpayGlobal
     const PAYMENT_NOT_ALLOWED = 0x02;
     const PAYMENT_NOT_AVAILABLE = 0x03;
 
+    /** Stream cipher historically used by openssl_seal()/openssl_open(). */
+    const SEAL_CIPHER_LEGACY = 'RC4';
+
+    /** Block cipher used when RC4 is unavailable; also accepted by the NETOPIA gateway. */
+    const SEAL_CIPHER_DEFAULT = 'aes-256-cbc';
+
+    /** OpenSSL 3.0 release: RC4 was moved to the (disabled-by-default) legacy provider. */
+    const OPENSSL_3_VERSION_NUMBER = 0x30000000;
+
+    /**
+     * Pick the symmetric cipher for openssl_seal().
+     *
+     * OpenSSL 3.0 removed RC4 from the default provider, so openssl_seal() with
+     * RC4 fails with "digital envelope routines::unsupported" (error 0308010C).
+     * On OpenSSL 3+ fall back to aes-256-cbc, which requires an IV that must be
+     * relayed to the decrypting party.
+     *
+     * @return string
+     */
+    public static function getSealCipher()
+    {
+        if (defined('OPENSSL_VERSION_NUMBER') && OPENSSL_VERSION_NUMBER >= self::OPENSSL_3_VERSION_NUMBER) {
+            return self::SEAL_CIPHER_DEFAULT;
+        }
+
+        return self::SEAL_CIPHER_LEGACY;
+    }
+
     public static function buildCRC($params)
     {
         $crc_pairs = [];

--- a/src/Mobilpay/Payment/Request.php
+++ b/src/Mobilpay/Payment/Request.php
@@ -159,10 +159,12 @@ class Request
      * @param resource $public_key - obtained by calling openssl_pkey_get_public
      * @param string & $env_key    - returns envelope key base64 encoded or null if function fails
      * @param string & $enc_data   - returns data to post base64 encoded or null if function fails
+     * @param string & $cipher     - returns the symmetric cipher used to seal the data
+     * @param string & $iv         - returns the base64 encoded IV (null for stream ciphers such as RC4)
      *
      * @return boolean
      */
-    public function buildAccessParameters($public_key, &$env_key, &$enc_data)
+    public function buildAccessParameters($public_key, &$env_key, &$enc_data, &$cipher = null, &$iv = null)
     {
         $params = $this->buildParametersList();
         if (is_null($params)) {
@@ -171,16 +173,21 @@ class Request
         $src_data = MobilpayGlobal::buildQueryString($params);
         $enc_data = '';
         $env_keys = [];
-        $cipher_algo = 'RC4';
-        $result = openssl_seal($src_data, $enc_data, $env_keys, [$public_key], $cipher_algo);
+        $iv_raw = null;
+        $cipher_algo = MobilpayGlobal::getSealCipher();
+        $result = openssl_seal($src_data, $enc_data, $env_keys, [$public_key], $cipher_algo, $iv_raw);
         if ($result === false) {
             $env_key = null;
             $enc_data = null;
+            $cipher = null;
+            $iv = null;
 
             return false;
         }
         $env_key = base64_encode($env_keys[0]);
         $enc_data = base64_encode($enc_data);
+        $cipher = $cipher_algo;
+        $iv = $iv_raw !== null ? base64_encode($iv_raw) : null;
 
         return true;
     }

--- a/src/Mobilpay/Payment/Request/RequestAbstract.php
+++ b/src/Mobilpay/Payment/Request/RequestAbstract.php
@@ -5,6 +5,7 @@ namespace Mobilpay\Payment\Request;
 use DOMDocument;
 use DOMNode;
 use Exception;
+use Mobilpay\MobilpayGlobal;
 
 /**
  * Class RequestAbstract
@@ -108,6 +109,18 @@ abstract class RequestAbstract
      */
     private $outEncData = null;
 
+    /**
+     * outCipher - symmetric cipher used by openssl_seal()
+     * must be relayed to the payment interface so it can decrypt the envelope
+     */
+    private $outCipher = null;
+
+    /**
+     * outIv - base64 encoded initialization vector produced by openssl_seal()
+     * null for stream ciphers (RC4); required by block ciphers such as aes-256-cbc
+     */
+    private $outIv = null;
+
     protected $_xmlDoc = null;
 
     protected $_requestIdentifier = null;
@@ -149,7 +162,7 @@ abstract class RequestAbstract
     /**
      * @throws Exception
      */
-    static public function factoryFromEncrypted($envKey, $encData, $privateKeyFilePath, $privateKeyPassword = null)
+    static public function factoryFromEncrypted($envKey, $encData, $privateKeyFilePath, $privateKeyPassword = null, $cipher = null, $iv = null)
     {
         $privateKey = null;
         if ($privateKeyPassword == null) {
@@ -183,8 +196,9 @@ abstract class RequestAbstract
         }
 
         $data = null;
-        $cipher_algo = 'RC4';
-        $result = @openssl_open($srcData, $data, $srcEnvKey, $privateKey, $cipher_algo);
+        $cipherAlgo = ($cipher !== null && $cipher !== '') ? $cipher : MobilpayGlobal::SEAL_CIPHER_LEGACY;
+        $ivRaw = ($iv !== null && $iv !== '') ? base64_decode($iv) : null;
+        $result = @openssl_open($srcData, $data, $srcEnvKey, $privateKey, $cipherAlgo, $ivRaw);
         if ($result === false) {
             throw new Exception('Failed decrypting data', self::ERROR_CONFIRM_FAILED_DECRYPT_DATA);
         }
@@ -340,12 +354,15 @@ abstract class RequestAbstract
         $publicKeys = [$publicKey];
         $encData = null;
         $envKeys = null;
-        $cipher_algo = 'RC4';
-        $result 	 = openssl_seal($srcData, $encData, $envKeys, $publicKeys, $cipher_algo);
+        $iv = null;
+        $cipherAlgo = MobilpayGlobal::getSealCipher();
+        $result 	 = openssl_seal($srcData, $encData, $envKeys, $publicKeys, $cipherAlgo, $iv);
 
         if ($result === false) {
             $this->outEncData = null;
             $this->outEnvKey = null;
+            $this->outCipher = null;
+            $this->outIv = null;
             $errorMessage = "Error while encrypting data! Reason:";
             while (($errorString = openssl_error_string())) {
                 $errorMessage .= $errorString."\n";
@@ -355,6 +372,8 @@ abstract class RequestAbstract
 
         $this->outEncData = base64_encode($encData);
         $this->outEnvKey = base64_encode($envKeys[0]);
+        $this->outCipher = $cipherAlgo;
+        $this->outIv = $iv !== null ? base64_encode($iv) : null;
     }
 
     public function getEnvKey()
@@ -365,6 +384,25 @@ abstract class RequestAbstract
     public function getEncData()
     {
         return $this->outEncData;
+    }
+
+    /**
+     * Symmetric cipher used to seal the request (e.g. RC4 or aes-256-cbc).
+     * Send it to the payment interface alongside env_key/enc_data so the
+     * gateway knows how to open the envelope.
+     */
+    public function getCipher()
+    {
+        return $this->outCipher;
+    }
+
+    /**
+     * Base64 encoded initialization vector produced by openssl_seal().
+     * null for stream ciphers (RC4); send it to the gateway for block ciphers.
+     */
+    public function getIv()
+    {
+        return $this->outIv;
     }
 
     public function getRequestIdentifier()


### PR DESCRIPTION
## Problem

`openssl_seal()`/`openssl_open()` hardcoded **RC4**. OpenSSL 3.0 moved RC4 to the disabled-by-default legacy provider, so `encrypt()` fails with:

```
Error while encrypting data! Reason:error:0308010C:digital envelope routines::unsupported
```

on any PHP build using OpenSSL 3+ (e.g. PHP 8.3/8.4 on modern distros).

## Fix

| File | Change |
|---|---|
| `Mobilpay/Global.php` | New `MobilpayGlobal::getSealCipher()` — returns `aes-256-cbc` on OpenSSL ≥ 3, `RC4` otherwise. Adds cipher constants. |
| `Payment/Request/RequestAbstract.php` | `encrypt()` seals with the selected cipher + IV; new `getCipher()`/`getIv()` getters. `factoryFromEncrypted()` gains optional `$cipher`/`$iv` to open block-cipher envelopes. |
| `Payment/Request.php` | `buildAccessParameters()` same seal fix with optional by-ref `&$cipher`/`&$iv` outputs. |

All changes are **additive / backward compatible** (new optional params + getters; no existing signature broken).

## ⚠ Required consumer wiring

`aes-256-cbc` needs the IV at decrypt time. Consumers must now relay `cipher` + `iv` alongside `env_key`/`data`:

**To gateway:**
```php
$card->encrypt($x509Path);
$fields = [
    'env_key' => $card->getEnvKey(),
    'data'    => $card->getEncData(),
    'cipher'  => $card->getCipher(), // new
    'iv'      => $card->getIv(),     // new (null on legacy RC4)
];
```

**IPN handler:**
```php
$req = RequestAbstract::factoryFromEncrypted(
    $_POST['env_key'], $_POST['data'], $privateKeyPath, null,
    $_POST['cipher'] ?? null, // new
    $_POST['iv'] ?? null      // new
);
```

## Test plan

- [x] `php -l` clean on all 3 files
- [x] Verified locally on OpenSSL 3.4.0 (RC4 absent): `getSealCipher()` → `aes-256-cbc`
- [x] Full `Card::encrypt()` → `factoryFromEncrypted()` round-trip with cipher+IV relay → **ROUND-TRIP OK**
- [ ] Validate against NETOPIA sandbox gateway end-to-end